### PR TITLE
Copy files on build

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,14 @@
+build:
+    dotnet build
+test:
+    dotnet test
+
+# helper commands for testing produced binaries
+init-project: clean-project
+    dotnet run --project ./src new /tmp/derp
+
+build-project:
+    dotnet run --project ./src build /tmp/derp /tmp/out
+
+clean-project:
+    rm -rf /tmp/derp

--- a/src/Service/Contract/IFileCopier.cs
+++ b/src/Service/Contract/IFileCopier.cs
@@ -1,0 +1,6 @@
+namespace Seagull.Service.Contract;
+
+public interface IFileCopier
+{
+    public void CopyFiles(string src, string dest);
+}

--- a/src/Service/Contract/IFileService.cs
+++ b/src/Service/Contract/IFileService.cs
@@ -7,4 +7,6 @@ public interface IFileService
     public string ReadTextFile(string path);
     public IEnumerable<string> ReadDirectoryContents(string path, string pattern = "");
     public bool DirectoryPathExists(string path);
+
+    public void CopyFile(string src, string dest);
 }

--- a/src/Service/FileCopier.cs
+++ b/src/Service/FileCopier.cs
@@ -1,0 +1,23 @@
+using System.Text.RegularExpressions;
+using Seagull.Service.Contract;
+
+namespace Seagull.Service;
+
+public partial class FileCopier(IFileService fileService) : IFileCopier
+{
+    private readonly Regex _filteredExtensions = FilterExtensionsRegex();
+    
+    public void CopyFiles(string src, string dest)
+    {
+        var files = fileService.ReadDirectoryContents(src);
+        var filteredFiles = files.Where(file => _filteredExtensions.Match(file).Success);
+        foreach (var file in filteredFiles)
+        {
+            var path = Path.Join(dest, file.Replace(src, string.Empty));
+            fileService.CopyFile(file, path);
+        }
+    }
+
+    [GeneratedRegex(@".+\.(?!(md|yml|scriban)$).+")]
+    private static partial Regex FilterExtensionsRegex();
+}

--- a/src/Service/FileService.cs
+++ b/src/Service/FileService.cs
@@ -48,6 +48,11 @@ public class FileService : IFileService
         return DirectoryExists(path);
     }
 
+    public void CopyFile(string src, string dest)
+    {
+        FileCopy(src, dest);
+    }
+
     protected virtual string PathGetDirectoryName(string path)
     {
         var directoryName = Path.GetDirectoryName(path);
@@ -81,8 +86,13 @@ public class FileService : IFileService
 
     protected virtual IEnumerable<string> DirectoryEnumerateFiles(string path, string pattern)
     {
-        return pattern != String.Empty
+        return pattern != string.Empty
             ? Directory.EnumerateFiles(path, pattern, SearchOption.AllDirectories)
             : Directory.EnumerateFiles(path);
+    }
+
+    protected virtual void FileCopy(string src, string dest)
+    {
+        File.Copy(src, dest, true);
     }
 }

--- a/src/Service/GenerateProjectService.cs
+++ b/src/Service/GenerateProjectService.cs
@@ -10,7 +10,7 @@ public class GenerateProjectService(ISerializer serializer, IFileService fileSer
     {
         fileService.CreateDirectory(path);
         fileService.CreateTextFile(Path.Join(path, "seagull.yml"), GenerateDefaultConfiguration());
-        fileService.CreateTextFile(Path.Join(path, "layout.html"), GenerateDefaultHtmlLayout());
+        fileService.CreateTextFile(Path.Join(path, "layout.scriban"), GenerateDefaultHtmlLayout());
     }
 
     protected string GenerateDefaultConfiguration()
@@ -20,7 +20,7 @@ public class GenerateProjectService(ISerializer serializer, IFileService fileSer
             Title = "Project title",
             Templates = new Dictionary<string, string>
             {
-                ["default"] = "layout.html",
+                ["default"] = "layout.scriban",
             }
         };
 

--- a/src/seagull.csproj
+++ b/src/seagull.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Markdig" Version="0.35.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Scriban" Version="5.9.1" />
     <PackageReference Include="YamlDotNet" Version="15.1.1" />
   </ItemGroup>

--- a/test/BuildProjectServiceTest.cs
+++ b/test/BuildProjectServiceTest.cs
@@ -14,6 +14,8 @@ public class BuildProjectServiceTest
     private readonly Mock<IFileService> _fileService = new();
     private readonly Mock<IMarkdownRendererService> _markdownRendererService = new();
     private readonly Mock<IMarkdownFileFactory> _markdownFileFactory = new();
+    private readonly Mock<IIndexGenerator> _indexGenerator = new();
+    private readonly Mock<IFileCopier> _fileCopier = new();
 
     [TestMethod]
     public void TestBuildProject()
@@ -85,7 +87,8 @@ public class BuildProjectServiceTest
                 _fileService.Object,
                 _markdownRendererService.Object,
                 _markdownFileFactory.Object,
-                new IndexGenerator(new HtmlTemplateParser())
+                _indexGenerator.Object,
+                _fileCopier.Object
             );
         buildProjectService.BuildProject(src, dest);
 

--- a/test/FileCopierTest.cs
+++ b/test/FileCopierTest.cs
@@ -1,0 +1,37 @@
+using System.Linq.Expressions;
+using Moq;
+using Seagull.Service;
+using Seagull.Service.Contract;
+
+namespace test;
+
+[TestClass]
+public class FileCopierTest
+{
+    private readonly Mock<IFileService> _fileService = new();
+
+    [TestMethod]
+    public void TestFileCopy()
+    {
+        var files = new List<string>
+        {
+            "foo.md",
+            "layout.scriban",
+            "seagull.yml",
+            "cat.png",
+        };
+
+        Expression<Func<IFileService, IEnumerable<string>>> readDirectory = fs =>
+            fs.ReadDirectoryContents(It.IsAny<string>(), It.IsAny<string>());
+        _fileService.Setup(readDirectory).Returns(files);
+
+        Expression<Action<IFileService>> copyFile = fs => fs.CopyFile(It.IsAny<string>(), It.IsAny<string>());
+        _fileService.Setup(copyFile);
+
+        var fileCopier = new FileCopier(_fileService.Object);
+        fileCopier.CopyFiles("foo", "bar");
+        
+        _fileService.Verify(readDirectory, Times.Once);
+        _fileService.Verify(copyFile, Times.Once);
+    }
+}

--- a/test/GenerateProjectServiceTest.cs
+++ b/test/GenerateProjectServiceTest.cs
@@ -23,7 +23,7 @@ public class GenerateProjectServiceTest
         var path = "/foo/bar";
         var fileContent = $"title: {config.Title}";
         var configFilePath = $"{path}/seagull.yml";
-        var layoutFilePath = $"{path}/layout.html";
+        var layoutFilePath = $"{path}/layout.scriban";
 
         Expression<Func<ISerializer, string>> serialize = s => s.Serialize(It.IsAny<Configuration>());
         _serializer.Setup(serialize).Returns(fileContent);


### PR DESCRIPTION
- Updates generated projects to use a `.scriban` suffix
- Copies everything in the input directory (except for md, yml and scriban files) to the output directory on build
- Introduces the Microsoft Application Builder extension for Dependency Injection
- Adds a justfile with utility commands